### PR TITLE
add direct link to manuscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Feedback and recommendations for an update of the checklist can be provided here
 
 You can cite the Transparency Checklist as follows: 
 
-Aczel, B., Szaszi, B., Sarafoglou, A. Kekecs, Z., Kucharský, Š., Benjamin, D., ... & Wagenmakers, E.-J. (2019). A consensus-based transparency checklist. *Nature Human Behavior*, 1--3. doi:10.1038/s41562-019-0772-6
+Aczel, B., Szaszi, B., Sarafoglou, A. Kekecs, Z., Kucharský, Š., Benjamin, D., ... & Wagenmakers, E.-J. (2019). A consensus-based transparency checklist. *Nature Human Behavior*, 1--3. [doi:10.1038/s41562-019-0772-6](https://doi.org/10.1038/s41562-019-0772-6)
 
 BibTeX entry:
 

--- a/ShortTransparencyChecklist/www/doc/introText.Rmd
+++ b/ShortTransparencyChecklist/www/doc/introText.Rmd
@@ -21,7 +21,7 @@ The Transparency Checklist is a comprehensive checklist that researchers can use
 You can cite the Transparency Checklist as follows: 
 
 
-Aczel, B., Szaszi, B., Sarafoglou, A. Kekecs, Z., Kucharský, Š., Benjamin, D., ... & Wagenmakers, E.-J. (2019). A consensus-based transparency checklist. *Nature Human Behaviour*, 1--3. doi:10.1038/s41562-019-0772-6
+Aczel, B., Szaszi, B., Sarafoglou, A. Kekecs, Z., Kucharský, Š., Benjamin, D., ... & Wagenmakers, E.-J. (2019). A consensus-based transparency checklist. *Nature Human Behaviour*, 1--3. [doi:10.1038/s41562-019-0772-6](https://doi.org/10.1038/s41562-019-0772-6)
 
 
 -----

--- a/TransparencyChecklist/www/doc/introText.Rmd
+++ b/TransparencyChecklist/www/doc/introText.Rmd
@@ -21,7 +21,7 @@ The Transparency Checklist is a comprehensive checklist that researchers can use
 You can cite the Transparency Checklist as follows: 
 
 
-Aczel, B., Szaszi, B., Sarafoglou, A. Kekecs, Z., Kucharský, Š., Benjamin, D., ... & Wagenmakers, E.-J. (2019). A consensus-based transparency checklist. *Nature Human Behaviour*, 1--3. [doi:10.1038/s41562-019-0772-6]https://doi.org/10.1038/s41562-019-0772-6)
+Aczel, B., Szaszi, B., Sarafoglou, A. Kekecs, Z., Kucharský, Š., Benjamin, D., ... & Wagenmakers, E.-J. (2019). A consensus-based transparency checklist. *Nature Human Behaviour*, 1--3. [doi:10.1038/s41562-019-0772-6](https://doi.org/10.1038/s41562-019-0772-6)
 
 
 -----

--- a/TransparencyChecklist/www/doc/introText.Rmd
+++ b/TransparencyChecklist/www/doc/introText.Rmd
@@ -21,7 +21,7 @@ The Transparency Checklist is a comprehensive checklist that researchers can use
 You can cite the Transparency Checklist as follows: 
 
 
-Aczel, B., Szaszi, B., Sarafoglou, A. Kekecs, Z., Kucharský, Š., Benjamin, D., ... & Wagenmakers, E.-J. (2019). A consensus-based transparency checklist. *Nature Human Behaviour*, 1--3. doi:10.1038/s41562-019-0772-6
+Aczel, B., Szaszi, B., Sarafoglou, A. Kekecs, Z., Kucharský, Š., Benjamin, D., ... & Wagenmakers, E.-J. (2019). A consensus-based transparency checklist. *Nature Human Behaviour*, 1--3. [doi:10.1038/s41562-019-0772-6]https://doi.org/10.1038/s41562-019-0772-6)
 
 
 -----


### PR DESCRIPTION
This adds a direct clickable URL that links to the corresponding publication in the README and the online documentation

This replaces #2 